### PR TITLE
Update Node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: '/tmp/ssh-auth.sock'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/main/index.js'
   post: 'dist/cleanup/index.js'
 branding:


### PR DESCRIPTION
# Summary 

Update Node version from 12 to 16

# Rationale

Node 12 reached its End of Life on April 2022, and because of that GitHub is deprecating it as a runner and giving a warning on actions using it. More information: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/