### PR TITLE
Automatically build new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: "release"
+
+on: create
+
+jobs:
+  release:
+    name: build new release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/release-github-actions@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: "units-test"
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Manually creating new releases is a bit of a process and it’s easy to forget to build a new release. This should mostly automate it.