### PR TITLE
Don’t create minor version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: "release"
+name: "Release"
 
 on: create
 
@@ -8,3 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/release-github-actions@v6
+        with:
+          CREATE_MINOR_VERSION_TAG: false
+          COMMIT_NAME: "kielabokkie"
+          COMMIT_EMAIL: "kielabokkie@gmail.com"


### PR DESCRIPTION
Prevent creation of minor version tag (i.e. `v1.3`)