### PR TITLE
Fix cleanup failure on macOS Github runners

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -3,7 +3,7 @@ const execa = require('execa')
 async function run() {
   console.log('Stopping ssh-agent')
 
-  await execa('kill -9 $(pidof ssh-agent)', { shell: true });
+  await execa('kill -9 $(ps -e | grep -m1 "[s]sh-agent" | awk \'{print $1}\')', { shell: true });
 }
 
 run()


### PR DESCRIPTION
Finds the process id of the ssh-agent by using `ps` instead of `pidof` as the latter does not work on macOS runners

Closes #24